### PR TITLE
Add custom fields to Profile > Basics, include in all AI prompts

### DIFF
--- a/src/panel/lib/claude.ts
+++ b/src/panel/lib/claude.ts
@@ -254,6 +254,7 @@ export function buildFitPrompt(job: ScrapedJob, profile: MasterProfile): string 
 
 ## Candidate Profile
 Name: ${profile.basics.name}
+${(profile.basics.customFields ?? []).filter(f => f.label && f.value).map(f => `${f.label}: ${f.value}`).join('\n')}
 Summary: ${profile.summary}
 Total professional experience: ${totalYoE}
 Current role: ${currentTenure}
@@ -421,10 +422,15 @@ Do not include any other text outside these two sections.`
     return `${header}\n${roleLines}`
   }).join('\n\n')
 
+  const customBasics = (profile.basics.customFields ?? [])
+    .filter(f => f.label && f.value)
+    .map(f => `${f.label}: ${f.value}`)
+    .join('\n')
+
   const profileBlock = `Name: ${profile.basics.name}
 Location: ${profile.basics.location || 'not specified'}
 LinkedIn: ${profile.basics.linkedin || 'not specified'}
-Summary: ${profile.summary || 'not provided'}
+${customBasics ? customBasics + '\n' : ''}Summary: ${profile.summary || 'not provided'}
 
 Experience:
 ${experienceBlock}
@@ -513,6 +519,10 @@ export function buildFormFillPrompt(
   const contextAnswers = (profile.contextNotes ?? [])
     .map(n => `${n.label ? n.label + ': ' : ''}${n.content}`)
     .join('\n')
+  const customBasicsLines = (basics.customFields ?? [])
+    .filter(f => f.label && f.value)
+    .map(f => `${f.label}: ${f.value}`)
+    .join('\n')
 
   return `You are filling in a job application form. Map the form fields below to the candidate's data.
 
@@ -522,8 +532,7 @@ Email: ${basics.email}
 Phone: ${basics.phone}
 Location: ${basics.location}
 LinkedIn: ${basics.linkedin}
-${basics.website ? `Website: ${basics.website}` : ''}
-${contextAnswers ? `\nAdditional info (use for questions about notice period, right to work, salary, etc.):\n${contextAnswers}` : ''}
+${basics.website ? `Website: ${basics.website}\n` : ''}${customBasicsLines ? customBasicsLines + '\n' : ''}${contextAnswers ? `\nAdditional info (use for questions about notice period, right to work, salary, etc.):\n${contextAnswers}` : ''}
 
 ## Cover letter (use for any cover letter or personal statement field)
 ${coverLetter.slice(0, 1500)}

--- a/src/panel/tabs/ProfileTab.tsx
+++ b/src/panel/tabs/ProfileTab.tsx
@@ -48,6 +48,7 @@ export default function ProfileTab() {
         location: incoming.basics?.location || existing.basics.location,
         linkedin: incoming.basics?.linkedin || existing.basics.linkedin,
         website: incoming.basics?.website || existing.basics.website,
+        customFields: existing.basics.customFields,
       },
       summary: incoming.summary || existing.summary,
       experiences: incoming.experiences?.length ? incoming.experiences : existing.experiences,
@@ -308,6 +309,48 @@ export default function ProfileTab() {
                 </div>
               </div>
             ))}
+
+            {/* Custom fields */}
+            {(profile.basics.customFields ?? []).map((cf, i) => (
+              <div key={i} className="flex items-center gap-1.5">
+                <input
+                  type="text"
+                  value={cf.label}
+                  onChange={e => {
+                    const next = [...(profile.basics.customFields ?? [])]
+                    next[i] = { ...cf, label: e.target.value }
+                    updateBasics({ customFields: next })
+                  }}
+                  placeholder="Field name"
+                  className="input-base w-28 text-xs"
+                />
+                <input
+                  type="text"
+                  value={cf.value}
+                  onChange={e => {
+                    const next = [...(profile.basics.customFields ?? [])]
+                    next[i] = { ...cf, value: e.target.value }
+                    updateBasics({ customFields: next })
+                  }}
+                  placeholder="Value"
+                  className="input-base flex-1 text-xs"
+                />
+                <CopyFieldButton value={cf.value} />
+                <button
+                  onClick={() => {
+                    const next = (profile.basics.customFields ?? []).filter((_, j) => j !== i)
+                    updateBasics({ customFields: next })
+                  }}
+                  className="text-xs text-red-400 hover:text-red-300 px-1"
+                >✕</button>
+              </div>
+            ))}
+            <button
+              onClick={() => updateBasics({ customFields: [...(profile.basics.customFields ?? []), { label: '', value: '' }] })}
+              className="text-[10px] text-slate-400 hover:text-slate-600 dark:hover:text-slate-300 transition-colors"
+            >
+              + Add field
+            </button>
           </div>
         </Section>
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -36,6 +36,7 @@ export interface MasterProfile {
     location: string
     linkedin: string
     website?: string
+    customFields?: { label: string; value: string }[]
   }
   summary: string
   experiences: Experience[]


### PR DESCRIPTION
Adds a dynamic key-value custom fields section under the fixed basics fields (name, email, phone, etc). Custom fields are included in CV/CL generation, fit analysis, and form fill prompts so the AI has full context. Fields survive LinkedIn/resume re-imports.